### PR TITLE
remove unsupported --fast-parser

### DIFF
--- a/autoload/mypy.vim
+++ b/autoload/mypy.vim
@@ -11,5 +11,5 @@
 
 function mypy#ExecuteMyPy()
   silent !clear
-  execute "!mypy --ignore-missing-imports --follow-imports=skip --fast-parser " . bufname("%")
+  execute "!mypy --ignore-missing-imports --follow-imports=skip  " . bufname("%")
 endfunction


### PR DESCRIPTION
Current mypy implementation doesn't support --fast-parser option.
PR to remove.